### PR TITLE
o/servicestate: more explanative error messages when memory cgroup is disabled & separation of quota retrieval for the daemon and the overlord

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -134,6 +134,8 @@ var (
 	SysfsDir        string
 
 	FeaturesDir string
+
+	CGroupsStatusFile string
 )
 
 const (
@@ -428,6 +430,8 @@ func SetRootDir(rootdir string) {
 
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
+
+	CGroupsStatusFile = filepath.Join(rootdir, "/proc/cgroups")
 
 	opensuseTWWithLibexec := func() bool {
 		// XXX: this is pretty naive if openSUSE ever starts going back

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -30,6 +30,8 @@ var (
 	CheckSystemdVersion      = checkSystemdVersion
 	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
 	ServiceControlTs         = serviceControlTs
+	CGroupsFilePath          = cgroupsFilePath
+	SetCGroupsFilePath       = setCGroupsFilePath
 )
 
 type QuotaStateUpdated = quotaStateUpdated

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -20,8 +20,12 @@
 package servicestate
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
@@ -34,6 +38,11 @@ import (
 
 var (
 	systemdVersionError error
+	memoryCGroupError   error
+)
+
+var (
+	cgroupsFilePath = dirs.CGroupsStatusFile
 )
 
 func checkSystemdVersion() {
@@ -42,9 +51,62 @@ func checkSystemdVersion() {
 
 func init() {
 	checkSystemdVersion()
+	checkMemoryCGroupEnabled()
+}
+
+func checkMemoryCGroupEnabled() {
+	memoryCGroupError = memoryCGroupEnabled()
+}
+
+// added to enable path update for testing purposes
+func setCGroupsFilePath(path string) {
+	cgroupsFilePath = path
+	checkMemoryCGroupEnabled()
+}
+
+// since the control groups can be enabled/disabled without the kernel config the only
+// way to identify the status of memory control groups is via /proc/cgroups
+// "cat /proc/cgroups | grep memory" returns the active status of memory control group
+// and the 3rd parameter is the status
+// 0 => false => disabled
+// 1 => true => enabled
+func memoryCGroupEnabled() error {
+	cgroupsFile, err := os.Open(cgroupsFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open cgroups file: %v", err)
+	}
+	defer cgroupsFile.Close()
+	scanner := bufio.NewScanner(cgroupsFile)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "memory\t") {
+			memoryCgroupValues := strings.Fields(line)
+			if len(memoryCgroupValues) >= 4 { // assuming any increase in size will lead to values added to the end
+				isMemoryEnabled := memoryCgroupValues[3] == "1"
+				if !isMemoryEnabled {
+					return fmt.Errorf("cannot retrieve quota information, memory cgroup is disabled on this system")
+				}
+				return nil
+			}
+			// change in size, should investigate the new structure
+			return fmt.Errorf("cannot parse memory control group configuration")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("cannot read %v contents: %v", cgroupsFilePath, err)
+	}
+
+	// no errors so far but the only path here is the cgroups file without the memory line
+	return fmt.Errorf("cannot retrieve memory cgroup configuration, it is not available in the kernel config")
 }
 
 func quotaGroupsAvailable(st *state.State) error {
+	if memoryCGroupError != nil {
+		return memoryCGroupError
+	}
+
 	// check if the systemd version is too old
 	if systemdVersionError != nil {
 		return fmt.Errorf("cannot use quotas with incompatible systemd: %v", systemdVersionError)
@@ -122,6 +184,10 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 // TODO: currently this only supports removing leaf sub-group groups, it doesn't
 // support removing parent quotas, but probably it makes sense to allow that too
 func RemoveQuota(st *state.State, name string) (*state.TaskSet, error) {
+	if memoryCGroupError != nil {
+		return nil, memoryCGroupError
+	}
+
 	if snapdenv.Preseeding() {
 		return nil, fmt.Errorf("removing quota groups not supported while preseeding")
 	}

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -21,6 +21,7 @@ package servicestate_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -52,10 +53,10 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 
 	// we don't need the EnsureSnapServices ensure loop to run by default
 	servicestate.MockEnsuredSnapServices(s.mgr, true)
-
 	// we enable quota-groups by default
 	s.state.Lock()
 	defer s.state.Unlock()
+
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()
@@ -64,6 +65,23 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 	r := systemd.MockSystemdVersion(248, nil)
 	s.AddCleanup(r)
 	servicestate.CheckSystemdVersion()
+
+	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
+	if _, err := os.Stat(filepath.Dir(cgroupsPath)); os.IsNotExist(err) {
+		err := os.Mkdir(filepath.Dir(cgroupsPath), 0777)
+		c.Assert(err, IsNil)
+	}
+	cgroupsFile, err := os.Create(cgroupsPath)
+	c.Assert(err, IsNil)
+	defer cgroupsFile.Close()
+	// memory is enabled & file size is reduced as we only check for memory at this point
+	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
+cpuset	6	3	1
+cpu	3	133	1
+memory	2	223	1
+devices	10	135	1`)
+	c.Assert(err, IsNil)
+	cgroupsFile.Sync()
 }
 
 type quotaGroupState struct {
@@ -657,7 +675,6 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
-
 	_, err = servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
@@ -928,6 +945,229 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 
 	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
+}
+
+func (s *quotaControlSuite) TestMemoryCGroupDisabled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	memoryCGroupFile := servicestate.CGroupsFilePath
+	defer func() {
+		servicestate.SetCGroupsFilePath(memoryCGroupFile)
+	}()
+
+	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
+	cgroupsFile, err := os.Create(cgroupsPath)
+	c.Assert(err, IsNil)
+	defer cgroupsFile.Close()
+	// memory is enabled & file size is reduced as we only check for memory at this point
+	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
+cpuset	6	3	1
+cpu	3	133	1
+memory	2	223	0
+devices	10	135	1`)
+	c.Assert(err, IsNil)
+	cgroupsFile.Sync()
+	// reset memory cgroup status with the enabled file
+	servicestate.SetCGroupsFilePath(cgroupsPath)
+
+	// check if all operations fail with the expected error message
+	errExpected := `cannot retrieve quota information, memory cgroup is disabled on this system`
+	_, err = servicestate.AllQuotas(s.state)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.GetQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.RemoveQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+}
+
+func (s *quotaControlSuite) TestMemoryCGroupEnabled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	memoryCGroupFile := servicestate.CGroupsFilePath
+	defer func() {
+		servicestate.SetCGroupsFilePath(memoryCGroupFile)
+	}()
+
+	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
+	cgroupsFile, err := os.Create(cgroupsPath)
+	c.Assert(err, IsNil)
+	defer cgroupsFile.Close()
+	// memory is enabled & file size is reduced as we only check for memory at this point
+	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
+cpuset	6	3	1
+cpu	3	133	1
+memory	2	223	1
+devices	10	135	1`)
+	c.Assert(err, IsNil)
+	cgroupsFile.Sync()
+
+	// reset memory cgroup status with the enabled file
+	servicestate.SetCGroupsFilePath(cgroupsPath)
+
+	// check if all operations fail with the expected error message
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `cannot use snap \"test-snap\" in group \"foo\": snap \"test-snap\" is not installed`)
+
+	_, err = servicestate.RemoveQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `cannot remove non-existent quota group \"foo\"`)
+
+	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `group \"foo\" does not exist`)
+
+	_, err = servicestate.AllQuotas(s.state)
+	c.Assert(err, IsNil)
+
+	_, err = servicestate.GetQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `quota not found`)
+}
+
+func (s *quotaControlSuite) TestMemoryCGroupMissingFile(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	memoryCGroupFile := servicestate.CGroupsFilePath
+	defer func() {
+		servicestate.SetCGroupsFilePath(memoryCGroupFile)
+	}()
+
+	// reset memory cgroup status with the non-existing file
+	cgroupsPath := dirs.GlobalRootDir + "/missing_file"
+	servicestate.SetCGroupsFilePath(cgroupsPath)
+
+	// check if all operations fail with the expected error message
+	errExpected := fmt.Sprintf(`cannot open cgroups file: open %v: no such file or directory`, cgroupsPath)
+	_, err := servicestate.AllQuotas(s.state)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.GetQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.RemoveQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+}
+
+func (s *quotaControlSuite) TestMemoryCGroupMalformed(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	memoryCGroupFile := servicestate.CGroupsFilePath
+	defer func() {
+		servicestate.SetCGroupsFilePath(memoryCGroupFile)
+	}()
+
+	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
+	cgroupsFile, err := os.Create(cgroupsPath)
+	c.Assert(err, IsNil)
+	defer cgroupsFile.Close()
+	// each configuration has 3 fields instead of 4
+	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled	extra_field
+cpuset	6	3
+cpu	3	133
+memory	2	223
+devices	10	135`)
+	c.Assert(err, IsNil)
+	cgroupsFile.Sync()
+
+	// reset memory cgroup status with the disabled file
+	servicestate.SetCGroupsFilePath(cgroupsPath)
+
+	// check if all operations fail with the expected error message
+	errExpected := `cannot parse memory control group configuration`
+	_, err = servicestate.AllQuotas(s.state)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.GetQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.RemoveQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+}
+
+func (s *quotaControlSuite) TestMemoryCGroupMissingMemory(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	memoryCGroupFile := servicestate.CGroupsFilePath
+	defer func() {
+		servicestate.SetCGroupsFilePath(memoryCGroupFile)
+	}()
+
+	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
+	cgroupsFile, err := os.Create(cgroupsPath)
+	c.Assert(err, IsNil)
+	defer cgroupsFile.Close()
+	// memory is enabled & file size is reduced as we only check for memory at this point
+	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
+cpuset	6	3	1
+cpu	3	133	1
+devices	10	135	1`)
+	c.Assert(err, IsNil)
+	cgroupsFile.Sync()
+	// reset memory cgroup status with the enabled file
+	servicestate.SetCGroupsFilePath(cgroupsPath)
+
+	// check if all operations fail with the expected error message
+	errExpected := `cannot retrieve memory cgroup configuration, it is not available in the kernel config`
+	_, err = servicestate.AllQuotas(s.state)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.GetQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.RemoveQuota(s.state, "foo")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
+
+	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, errExpected)
 }
 
 func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {

--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -32,11 +32,18 @@ var ErrQuotaNotFound = errors.New("quota not found")
 // AllQuotas returns all currently tracked quota groups in the state. They are
 // validated for consistency using ResolveCrossReferences before being returned.
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
+	if memoryCGroupError != nil {
+		return nil, memoryCGroupError
+	}
 	return internal.AllQuotas(st)
 }
 
 // GetQuota returns an individual quota group by name.
 func GetQuota(st *state.State, name string) (*quota.Group, error) {
+	if memoryCGroupError != nil {
+		return nil, memoryCGroupError
+	}
+
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In case if the memory control group (cgroup) isn't enabled in the system any regarding command should indicate that memory cgroup is disabled

```$ snap quotas
No quota groups defined.
```

With the change the error message reflects the fact that memory cgroup is disabled

```$ snap quotas
error: cannot retrieve quota information, memory cgroup is disabled on this system
```
Also the quota retrieval is handled by the same interface for the requests coming to the daemon and any internal usage under overlord. The retrieval is decoupled to enable checks for end users while ensuring the 